### PR TITLE
cortex-a53: Use arch-arm/bionic/memchr.v7a.S instead of old one

### DIFF
--- a/libc/arch-arm/cortex-a53/cortex-a53.mk
+++ b/libc/arch-arm/cortex-a53/cortex-a53.mk
@@ -15,4 +15,4 @@ libc_bionic_src_files_arm += \
     arch-arm/krait/bionic/memmove.S
 
 libc_bionic_src_files_arm += \
-    arch-arm/cortex-a15/bionic/memchr.S
+    arch-arm/bionic/memchr.v7a.S


### PR DESCRIPTION
Signed-off-by: Men_in_black007 sanyam.53jain@gmail.com
