### PR TITLE
cortex-a7: set proper memcmp.S path

### DIFF
--- a/libc/arch-arm/cortex-a7/cortex-a7.mk
+++ b/libc/arch-arm/cortex-a7/cortex-a7.mk
@@ -12,7 +12,7 @@ libc_bionic_src_files_arm += \
     arch-arm/cortex-a15/bionic/strlen.S \
 
 libc_bionic_src_files_arm += \
-    arch-arm/generic/bionic/memcmp.S \
+    arch-arm/bionic/memcmp.S \
 
 libc_bionic_src_files_arm += \
     arch-arm/denver/bionic/memmove.S \


### PR DESCRIPTION
Reference: http://review.cyanogenmod.org/#/c/105507/
